### PR TITLE
Add `isodd(x)` to prevent BigInt conversion.

### DIFF
--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -330,9 +330,8 @@ flipsign(x::T, y::T) where {T<:XBS} = flipsign_int(x, y)
 # this doesn't catch flipsign(x::BBS, y::BBS), which is more specific in Base
 flipsign(x::UBS, y::UBS) = flipsign_int(promote(x, y)...) % typeof(x)
 
-
 # Cheaper isodd, to avoid BigInt.  NOTE: Base.iseven is defined in terms of isodd.
-isodd(a::BitInteger) = isodd(a % Int)  # only depends on the final bit! :)
+isodd(a::XBI) = isodd(a % Int)  # only depends on the final bit! :)
 
 
 # * arithmetic operations

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -3,7 +3,7 @@
 module BitIntegers
 
 import Base: &, *, +, -, <, <<, <=, ==, >>, >>>, |, ~, AbstractFloat, add_with_overflow,
-             bswap, checked_abs, count_ones, div, flipsign, leading_zeros, mod,
+             bswap, checked_abs, count_ones, div, flipsign, isodd, leading_zeros, mod,
              mul_with_overflow, ndigits0zpb, promote_rule, rem, sub_with_overflow,
              trailing_zeros, typemax, typemin, unsigned, xor
 
@@ -329,6 +329,10 @@ flipsign(x::T, y::T) where {T<:XBS} = flipsign_int(x, y)
 
 # this doesn't catch flipsign(x::BBS, y::BBS), which is more specific in Base
 flipsign(x::UBS, y::UBS) = flipsign_int(promote(x, y)...) % typeof(x)
+
+
+# Cheaper isodd, to avoid BigInt.  NOTE: Base.iseven is defined in terms of isodd.
+isodd(a::BitInteger) = isodd(a % Int)  # only depends on the final bit! :)
 
 
 # * arithmetic operations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,8 +176,6 @@ end
         @test y >= x
         @test x == Y(i)
         @test y == X(j)
-        @test isodd(x) == isodd(i) == !iseven(x)
-        @test isodd(y) == isodd(j) == !iseven(y)
     end
 end
 
@@ -221,6 +219,13 @@ end
             @test flipsign(x, y) isa X
             @test signed(flipsign(x, y)) == flipsign(n, m)
         end
+    end
+    for (X, Y) in TypeCombos
+        x,y = X(i),Y(j)
+        @test isodd(x) == isodd(i) == !iseven(x)
+        @test isodd(y) == isodd(j) == !iseven(y)
+        # Test performance of isodd(x): doesn't allocate.
+        @test @allocated(isodd(x) && isodd(y)) == 0
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,6 +176,8 @@ end
         @test y >= x
         @test x == Y(i)
         @test y == X(j)
+        @test isodd(x) == isodd(i) == !iseven(x)
+        @test isodd(y) == isodd(j) == !iseven(y)
     end
 end
 


### PR DESCRIPTION
:) Also this one!

Before this, `isodd(Int256(2))` was calling `Base.isodd`, which uses `rem`:
https://github.com/JuliaLang/julia/blob/v1.0.2/base/int.jl#L75

Since `rem` is currently defined using `BigInt`, this meant `isodd` had conversions to `BigInt`. This PR just truncates to an `Int` before calling `isodd`, since only the last bit is needed to determine if something is odd. 

I thought about converting to `Int8` since it's smaller, but I think _probably_ the native word-size instructions would be fastest? Either way seems reasonable to me! :)