### PR TITLE
make `bswap` work for all sizes on 1.6+ (fix #23)

### DIFF
--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -351,7 +351,7 @@ leading_zeros( x::XBI) = Int(ctlz_int(x))
 trailing_zeros(x::XBI) = Int(cttz_int(x))
 
 function bswap(x::XBI)
-    if sizeof(x) % 2 != 0
+    if VERSION < v"1.6" && sizeof(x) % 2 != 0
         # llvm instruction is invalid
         error("unimplemented")
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -147,7 +147,7 @@ end
     k, l = rand(Int(typemin(Int8)):-1, 2)
     for X in XInts
         for op in (~, bswap)
-            if sizeof(X) % 2 != 0 && op == bswap
+            if VERSION < v"1.6" && sizeof(X) % 2 != 0 && op == bswap
                 @test_throws ErrorException op(X(i))
                 continue
             end


### PR DESCRIPTION
On earlier versions, `Base.bswap_int` was segfaulting when
`sizeof` was not a multiple of 2.