### PR TITLE
make `rand(a:b)` work for user-defined integers

### DIFF
--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -543,7 +543,7 @@ struct SamplerRangeFast{U<:XBU,T<:XBI} <: Sampler{T}
     mask::U   # mask generated values before threshold rejection
 end
 
-SamplerRangeFast(r::AbstractUnitRange{T}) where T<:BitInteger =
+SamplerRangeFast(r::AbstractUnitRange{T}) where T<:XBI =
     SamplerRangeFast(r, uinttype(T))
 
 function SamplerRangeFast(r::AbstractUnitRange{T}, ::Type{U}) where {T,U}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -338,6 +338,7 @@ end
         k >>= rand(0:ndigits(k, base=2)-1)
         r = k < 0 ? (b:k:a) : (a:k:b)
         @test rand(r) ∈ r
+        @test rand(a:b) ∈ a:b
 
         # scalars
         ispow2(sizeof(X)) || VERSION >= v"1.4" || continue # cf. Issue #29053


### PR DESCRIPTION
Without this, tests failed on julia 1.9, because there `rand(a:k:b)` creates a `UnitRange{T}` where `a, k, b` are `T`s, instead of `UnitRange{Int}` on 1.8 (the indices of `r == a:k:b` are computed as `firstindex(r):lastindex(r)`).