### PR TITLE
better `promote_rule` for same signedness & bit widths

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,16 @@ julia> myint8"123" # the string macro is named like the type, in lower case
 123
 ```
 
-This is implemented using `primitive type` and julia intrinsics, the caveat being that it might
+These custom integers work as similarly as possible to bit integers defined in `Base`.
+In particular type promotion (`promote_rule`), with the additional following rules:
+when two types have the same signedness (both `<: Signed` or both `<: Unsigned`) and bit widths:
+* when both types are defined with `@define_integers`, `promote_rule` returns `Union{}`, which means
+  `promote_type` will end up returning an abstract type (via `typejoin`); the user can
+  disambiguate by defining its own `promote_rule`;
+* when one type is defined with `@define_integers` and the other is defined in `Base`,
+  `promote_rule` returns the former.
+
+This package is implemented using `primitive type` and julia intrinsics, the caveat being that it might
 not always be legal (e.g. in some julia versions, `Primes.factor(rand(UInt256))` used to
 make LLVM abort the program, while it was fine for `Int256`).
 

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -226,9 +226,16 @@ rem(x::XBI, ::Type{to}) where {to<:XBI} = _rem(x, to)
     if sizeof(X) > sizeof(Y)
         X
     elseif sizeof(X) == sizeof(Y)
-        X <: Unsigned ?
-            X :
+        if X <: Unsigned && Y <: Signed
+            X
+        elseif X <: Signed && Y <: Unsigned
             Y
+        elseif Y <: XBI
+            Base.Bottom # user needs to define its own rule
+        else
+            # custom integers win
+            X
+        end
     else
         Y
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,6 +112,28 @@ end
             @test T == Y
         end
     end
+    # promote_rule follows Base rules; for types with same size/signedness:
+    # - types from XBI win
+    # - do not resolve for two types from XBI
+    for X = (Int16, UInt16), Y = (MyInt8, MyUInt8)
+        # X bigger
+        @test promote_type(X, Y) == X == promote_type(Y, X)
+    end
+    for X = (Int16, UInt16, MyInt8, MyUInt8), Y = (Int24, UInt24)
+        # Y bigger
+        @test promote_type(X, Y) == Y == promote_type(Y, X)
+    end
+    # same size:
+    @test promote_type(Int8, MyInt8) == MyInt8
+    @test promote_type(Int8, MyUInt8) == MyUInt8
+    @test promote_type(UInt8, MyInt8) == UInt8
+    @test promote_type(UInt8, MyUInt8) == MyUInt8
+    @test promote_type(Int24, I24) == BitIntegers.AbstractBitSigned # typejoin
+    @test promote_type(Int24, U24) == U24
+    @test promote_type(UInt24, I24) == UInt24
+    @test promote_type(UInt24, U24) == BitIntegers.AbstractBitUnsigned
+    # fail for two BitIntegers types
+    @test_throws ErrorException U24(1) + UInt24(2) # can't resolve
 end
 
 

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -8,6 +8,7 @@ module TestBitIntegers
 using BitIntegers, Test
 
 BitIntegers.@define_integers 24
+BitIntegers.@define_integers 24 I24 U24 # to test mixed operations with Int24
 BitIntegers.@define_integers 200
 BitIntegers.@define_integers 8  MyInt8 MyUInt8
 
@@ -35,6 +36,8 @@ BitIntegers.@define_integers 8  MyInt8 MyUInt8
 end
 
 end # module TestBitIntegers
+
+using .TestBitIntegers: Int24, UInt24, I24, U24, MyInt8, MyUInt8
 
 const BInts = Base.BitInteger_types
 const XInts = (BitIntegers.BitInteger_types..., TestBitIntegers.UInt24, TestBitIntegers.Int24)


### PR DESCRIPTION
It was not defined consistently, in that `promote_rule(X, Y)` was not necessarily equal to `promote_rule(Y, X)`.

The idea here is to be as similar as possible to how `Base` works, with the additional rules of
* favoring `BitIntegers.jl` types over `Base` ones;
* not favoring one type over the other when both are defined with `@define_integers`

when both types have the same signedness and bit width.