### PR TITLE
add `rem(x::T, ::Type{T}) where {T<:XBI}`

### DIFF
--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -221,6 +221,8 @@ rem(x::Union{UBI,Bool}, ::Type{to}) where {to<:XBI} = _rem(x, to)
 rem(x::XBI, ::Type{to}) where {to<:UBI} = _rem(x, to)
 # to disambiguate
 rem(x::XBI, ::Type{to}) where {to<:XBI} = _rem(x, to)
+# to not let corresponding Base method (`T <: Integer`) take over (which errors)
+rem(x::T, ::Type{T}) where {T<:XBI} = x
 
 @generated function promote_rule(::Type{X}, ::Type{Y}) where {X<:XBI,Y<:UBI}
     if sizeof(X) > sizeof(Y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,6 +123,17 @@ end
         @test x % Y == x
         @test x % Y % X === x
     end
+    for X in XInts
+        x = X(i)
+        @test x % X === x
+        if X <: Signed
+            @test x % BitIntegers.AbstractBitSigned === x
+            @test x % Signed === x
+        else
+            @test x % BitIntegers.AbstractBitUnsigned === x
+            @test x % Unsigned === x
+        end
+    end
 end
 
 


### PR DESCRIPTION
This is necessary, as otherwise the corresponding method defined in `Base` is called (when `T` is abstract), and errors out.