### PR TITLE
fix `bswap` for odd number of bytes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BitIntegers"
 uuid = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 authors = ["Rafael Fourquet <fourquet.rafael@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,12 @@ recompiled (fixed by https://github.com/JuliaLang/julia/pull/30830);
 to errors and segfaults (cf. e.g. https://github.com/rfourquet/BitIntegers.jl/issues/1, fixed by
 https://github.com/JuliaLang/julia/pull/33283).
 
+
 ## Release notes
+
+### v0.3.1
+
+* fix incorrect `bswap` for odd byte-sizes ([#41](https://github.com/rfourquet/BitIntegers.jl/pull/41))
 
 ### v0.3.0
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -180,15 +180,25 @@ end
     k, l = rand(Int(typemin(Int8)):-1, 2)
     for X in XInts
         for op in (~, bswap)
-            if VERSION < v"1.6" && sizeof(X) % 2 != 0 && op == bswap
-                @test_throws ErrorException op(X(i))
-                continue
-            end
             x = op(X(i))
             @test x isa X
             @test x != X(i) # we assume sizeof(X) > 8
             @test op(x) == X(i)
         end
+        # bswap specific
+        if VERSION >= v"1.6"
+            for y = rand(X, 20)
+                x = bswap(y)
+                if iseven(sizeof(x))
+                    # test that default implemented matches bswap_simple
+                    @test x == BitIntegers.bswap_simple(y)
+                else
+                    # test that default implemented (i.e. bswap_simple) matches bswap_odd
+                    @test x == bswap_odd(y)
+                end
+            end
+        end
+
         for op in (count_ones, leading_zeros, trailing_zeros, leading_ones, trailing_ones)
             r = op(X(i))
             @test r isa Int


### PR DESCRIPTION
Fixes #38.

`bswap` was seeming to work well since Julia v1.6, but LLVM documents that `bswap` is valid only for an even number of bytes
(https://llvm.org/docs/LangRef.html#llvm-bswap-intrinsics), and a julia build with LLVM asserts enabled catches that.

NB: to enable LLVM asserts, put the following in "Make.user" :
```
FORCE_ASSERTIONS=1
LLVM_ASSERTIONS=1
```