### PR TITLE
add `bitrotate`

### DIFF
--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -3,6 +3,7 @@
 module BitIntegers
 
 import Base: &, *, +, -, <, <<, <=, ==, >>, >>>, |, ~, AbstractFloat, add_with_overflow,
+             bitrotate,
              bitstring, bswap, checked_abs, count_ones, div, flipsign, isodd, leading_zeros,
              mod, mul_with_overflow, ndigits0zpb, peek, promote_rule, read, rem, signed,
              sub_with_overflow, trailing_zeros, typemax, typemin, unsigned, write, xor
@@ -357,6 +358,12 @@ end
 @inline >>( x::UBI, y::Int) = 0 <= y ? x >> unsigned(y) :  x << unsigned(-y)
 @inline <<( x::UBI, y::Int) = 0 <= y ? x << unsigned(y) :  x >> unsigned(-y)
 @inline >>>(x::UBI, y::Int) = 0 <= y ? x >>> unsigned(y) : x << unsigned(-y)
+
+function bitrotate(x::T, k::Integer) where {T<:XBI}
+    l = (sizeof(T) << 3) % UInt
+    k::UInt = mod(k, l)
+    (x << k) | (x >>> (l-k))
+end
 
 count_ones(    x::XBI) = Int(ctpop_int(x))
 leading_zeros( x::XBI) = Int(ctlz_int(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,6 +257,22 @@ end
 end
 
 
+@testset "bit rotations" begin
+    for X in XInts
+        x = X(24)
+        l = 8*sizeof(X)
+        @test bitrotate(x, 2) == 4*x
+        @test bitrotate(x, l-1) == div(x, 2)
+        x = rand(X)
+        for k in (0, UInt8(13), UInt32(371), Int16(-123), Int64(-1072), BigInt(-21330))
+            y = @inferred bitrotate(x, k)
+            @test y isa X && bitrotate(y, k) == bitrotate(x, 2*k)
+            k isa Signed && @test bitrotate(y, -k) == x
+        end
+    end
+end
+
+
 @testset "arithmetic operations" begin
     for (X, Y) in TypeCombos
         T = promote_type(X, Y)


### PR DESCRIPTION
This seems to be missing so far. The implementation follows that for Julia integers, taking into account that the bit length may not be a power of 2.

Strangely, bit rotations are faster than shifts on my machine although they use two shifts:
```
julia> x = rand(UInt256); k = 50
julia> @btime bitrotate($x, $k); @btime $x << $k; @btime $x >>> $k;
  5.437 ns (0 allocations: 0 bytes)
  6.362 ns (0 allocations: 0 bytes)
  6.360 ns (0 allocations: 0 bytes)

julia> x = rand(UInt512); k = 50
julia> @btime bitrotate($x, $k); @btime $x << $k; @btime $x >>> $k;
  9.523 ns (0 allocations: 0 bytes)
  27.259 ns (0 allocations: 0 bytes)
  26.233 ns (0 allocations: 0 bytes)

julia> x = rand(UInt1024); k = 50
julia> @btime bitrotate($x, $k); @btime $x << $k; @btime $x >>> $k;
  30.658 ns (0 allocations: 0 bytes)
  126.578 ns (0 allocations: 0 bytes)
  129.565 ns (0 allocations: 0 bytes)
```
This is on master. For Julia 1.10.0-rc2 the timings fot `bitrotate` with `UInt256` and `UInt512` are twice the values above.

EDIT: `bitrotate` was added in Julia 1.5. Currently, BitIntegers.jl accepts all 1.x versions of Julia. This would have to be adjusted somehow. What about requiring Julia 1.5 for BitIntegers.jl?

EDIT 2: The poor timings for `<<` and `>>>` seems to improve for `k >= 64`:
```
julia> x = rand(UInt1024); k = 64
julia> @btime bitrotate($x, $k); @btime $x << $k; @btime $x >>> $k;
  32.790 ns (0 allocations: 0 bytes)
  15.624 ns (0 allocations: 0 bytes)
  14.275 ns (0 allocations: 0 bytes)
```
This seems to be a separate issue.