### PR TITLE
fix allocations in `div`/`rem` for types larger than 16 bytes

### DIFF
--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -407,11 +407,15 @@ rem(x::Unsigned, y::XBS) = rem(x, unsigned(abs(y)))
 
 mod(x::XBS, y::Unsigned) = rem(y + unsigned(rem(x, y)), y)
 
-# these operations fail LLVM for bigger types than UInt128
-div(x::T, y::T, ::typeof(RoundToZero)) where {T<:XBS} = sizeof(T) > 16 ? T(div(big(x), big(y))) : checked_sdiv_int(x, y)
-rem(x::T, y::T) where {T<:XBS} = sizeof(T) > 16 ? T(rem(big(x), big(y))) : checked_srem_int(x, y)
-div(x::T, y::T, ::typeof(RoundToZero)) where {T<:XBU} = sizeof(T) > 16 ? T(div(big(x), big(y))) : checked_udiv_int(x, y)
-rem(x::T, y::T) where {T<:XBU} = sizeof(T) > 16 ? T(rem(big(x), big(y))) : checked_urem_int(x, y)
+# these operations fail LLVM for bigger types than UInt128 on Julia versions < 1.11
+div(x::T, y::T, ::typeof(RoundToZero)) where {T<:XBS} =
+    (sizeof(T) > 16 && VERSION < v"1.11-") ? T(div(big(x), big(y))) : checked_sdiv_int(x, y)
+rem(x::T, y::T) where {T<:XBS} =
+    (sizeof(T) > 16 && VERSION < v"1.11-") ? T(rem(big(x), big(y))) : checked_srem_int(x, y)
+div(x::T, y::T, ::typeof(RoundToZero)) where {T<:XBU} =
+    (sizeof(T) > 16 && VERSION < v"1.11-") ? T(div(big(x), big(y))) : checked_udiv_int(x, y)
+rem(x::T, y::T) where {T<:XBU} =
+    (sizeof(T) > 16 && VERSION < v"1.11-") ? T(rem(big(x), big(y))) : checked_urem_int(x, y)
 
 # Compatibility fallbacks for the above definitions
 if VERSION < v"1.4.0-DEV.208"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,6 +271,9 @@ end
                  T
             @test op(X(5), Y(2)) isa TT
             @test op(X(5), Y(2)) == op(5, 2)
+            if (VERSION >= v"1.11-" || sizeof(T) <= 16) && sizeof(X) != 3 && sizeof(Y) != 3 # bug with [U]Int24
+                @test @allocated(op(X(5), Y(2))) == 0
+            end
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -271,8 +271,10 @@ end
                  T
             @test op(X(5), Y(2)) isa TT
             @test op(X(5), Y(2)) == op(5, 2)
-            if (VERSION >= v"1.11-" || sizeof(T) <= 16) && sizeof(X) != 3 && sizeof(Y) != 3 # bug with [U]Int24
-                @test @allocated(op(X(5), Y(2))) == 0
+            if VERSION >= v"1.11-" || sizeof(T) <= 16
+                f = (op, X, Y) -> op(X(5), Y(2))
+                f(op, X, Y)
+                @test @allocated(f(op, X, Y)) == 0
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,6 +257,10 @@ end
 end
 
 
+function test_noalloc(op::OP, x, y) where {OP}
+    @test @allocated(op(x, y)) == 0
+end
+
 @testset "arithmetic operations" begin
     for (X, Y) in TypeCombos
         T = promote_type(X, Y)
@@ -272,9 +276,7 @@ end
             @test op(X(5), Y(2)) isa TT
             @test op(X(5), Y(2)) == op(5, 2)
             if VERSION >= v"1.11-" || sizeof(T) <= 16
-                f = (op, X, Y) -> op(X(5), Y(2))
-                f(op, X, Y)
-                @test @allocated(f(op, X, Y)) == 0
+                test_noalloc(op, X(5), Y(2))
             end
         end
     end


### PR DESCRIPTION
Since 1.11 it's no longer necessary to use BigInt in `div`/`rem` for types greater than 16 bytes. Fixes #12.