### PR TITLE
make `show` work for 8-bits signed integers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BitIntegers"
 uuid = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 authors = ["Rafael Fourquet <fourquet.rafael@gmail.com>"]
-version = "0.3.3"
+version = "0.3.4"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ https://github.com/JuliaLang/julia/pull/33283).
 
 ## Release notes
 
+### v0.3.4
+
+* make `show` work for 8-bits signed integers ([#51](https://github.com/rfourquet/BitIntegers.jl/pull/51))
+
+### v0.3.3
+
+* fix a method ambiguity with `BigFloat` ([#50](https://github.com/rfourquet/BitIntegers.jl/pull/50))
+
 ### v0.3.2
 
 * add `bitrotate` ([#42](https://github.com/rfourquet/BitIntegers.jl/pull/42))

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -74,6 +74,15 @@ macro define_integers(n::Int, SI=nothing, UI=nothing)
         Base.widen(::Type{$(esc(SI))}) = $(esc(WSI))
         Base.widen(::Type{$(esc(UI))}) = $(esc(WUI))
 
+        if $n == 8
+            # at least from julia v1.6, a specific method is defined for Int8/UInt8,
+            # which is indirectly needed for example for `show`
+            # (more specifically for check_top_bit in convertto)
+            @inline function Core.is_top_bit_set(x::Union{$(esc(SI)), $(esc(UI))})
+                Core.eq_int(lshr_int(x, 7), trunc_int(typeof(x), 1))
+            end
+        end
+
         macro $(esc(sistr))(s)
             return parse($(esc(SI)), s)
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,23 @@ include("setup.jl")
     end
 end
 
+@testset "show" begin
+    @test string(MyInt8(1)) == "1" # issue #34
+    @test sprint(show, MyInt8(1)) == "1"
+    @test sprint(show, MyUInt8(1)) == "0x01"
+    for XX = (MyInt8, MyUInt8)
+        for _=1:5
+            xx = rand(XX)
+            @test string(xx) == string(Int(xx))
+            @test string(xx, base=16) == string(Int(xx), base=16)
+        end
+    end
+    for XX in XInts
+        xx = rand(XX)
+        @test string(xx) == string(big(xx))
+        @test string(xx, base=16) == string(big(xx), base=16)
+    end
+end
 
 @testset "string macros" begin
     @test   int256"1" ===   Int256(1)

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -5,7 +5,7 @@ using Serialization: serialize, deserialize
 # while v1.4 and below are supported:
 using BitIntegers: bitrotate
 
-module TestBitIntegers
+module TestBitIntegers ########################################################
 
 using BitIntegers, Test
 
@@ -37,7 +37,7 @@ BitIntegers.@define_integers 8  MyInt8 MyUInt8
     @test MyUInt8 <: Unsigned
 end
 
-end # module TestBitIntegers
+end # module TestBitIntegers ##################################################
 
 using .TestBitIntegers: Int24, UInt24, I24, U24, MyInt8, MyUInt8
 


### PR DESCRIPTION
Fix #34... this will be version 0.3.4!