### PR TITLE
faster hashing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BitIntegers"
 uuid = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 authors = ["Rafael Fourquet <fourquet.rafael@gmail.com>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ https://github.com/JuliaLang/julia/pull/33283).
 
 ## Release notes
 
+### v0.3.5
+
+* faster `hash`, on par with `Base` types ([#52](https://github.com/rfourquet/BitIntegers.jl/pull/52))
+
 ### v0.3.4
 
 * make `show` work for 8-bits signed integers ([#51](https://github.com/rfourquet/BitIntegers.jl/pull/51))

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -6,8 +6,7 @@ import Base: &, *, +, -, <, <<, <=, ==, >>, >>>, |, ~, AbstractFloat, add_with_o
              bitstring, bswap, checked_abs, count_ones, div, flipsign, hash, isodd, iseven,
              leading_zeros,
              mod, mul_with_overflow, ndigits0zpb, peek, promote_rule, read, rem, signed,
-             sub_with_overflow, top_set_bit, trailing_zeros, typemax, typemin, unsigned,
-             write, xor
+             sub_with_overflow, trailing_zeros, typemax, typemin, unsigned, write, xor
 
 using Base: GenericIOBuffer, add_int, and_int, ashr_int, bswap_int, checked_sadd_int,
             checked_sdiv_int, checked_smul_int, checked_srem_int, checked_ssub_int,
@@ -30,6 +29,10 @@ if VERSION >= v"1.4.0-DEV.114"
     check_top_bit(::Type{T}, x) where {T} = Core.check_top_bit(T, x)
 else
     check_top_bit(::Type{T}, x) where {T} = Core.check_top_bit(x)
+end
+
+if isdefined(Base, :top_set_bit)
+    import Base: top_set_bit
 end
 
 if VERSION >= v"1.5"

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -91,7 +91,10 @@ macro define_integers(n::Int, SI=nothing, UI=nothing)
         if $n < 64
             Base.hash(x::Union{$(esc(SI)), $(esc(UI))}, h::UInt) = hash(Int64(x), h)
         elseif $n == 64
-            Base.hash(x::Union{$(esc(SI)), $(esc(UI))}, h::UInt) = hash(bitcast(UInt64, x), h)
+            # these two methods must remain separate, as before v1.6, the second definition
+            # is wrong for negative integers of type SI
+            Base.hash(x::$(esc(SI)), h::UInt) = hash(bitcast(Int64, x), h)
+            Base.hash(x::$(esc(UI)), h::UInt) = hash(bitcast(UInt64, x), h)
         end
         # currently no specific method is defined for [U]Int128, so the generic hash
         # will work as well for integers bigger than 64 bits

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,6 +192,16 @@ end
 end
 
 
+@testset "hash" begin
+    for X in (XInts..., I32, U32, I64, U64, MyInt8, MyUInt8)
+        for xx in rand(X, 4)
+            hh = rand(UInt)
+            @test hash(xx, hh) == hash(big(xx), hh)
+        end
+    end
+end
+
+
 @testset "bit operations" begin
     i, j = rand(1:Int(typemax(Int8)), 2)
     k, l = rand(Int(typemin(Int8)):-1, 2)

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -9,13 +9,17 @@ module TestBitIntegers ########################################################
 
 using BitIntegers, Test
 
-BitIntegers.@define_integers 24
-BitIntegers.@define_integers 24 I24 U24 # to test mixed operations with Int24
-BitIntegers.@define_integers 200
-BitIntegers.@define_integers 8  MyInt8 MyUInt8
+@define_integers 24
+@define_integers 24 I24 U24 # to test mixed operations with Int24
+@define_integers 200
+@define_integers 8  MyInt8 MyUInt8
+
+# only for specific tests:
+@define_integers 32 I32 U32
+@define_integers 64 I64 U64
 
 # the following should throw, but is hard to test:
-# BitIntegers.@define_integers 8 MyInt8
+# @define_integers 8 MyInt8
 
 @testset "definitions" begin
     @test @isdefined Int24
@@ -39,7 +43,7 @@ end
 
 end # module TestBitIntegers ##################################################
 
-using .TestBitIntegers: Int24, UInt24, I24, U24, MyInt8, MyUInt8
+using .TestBitIntegers: Int24, UInt24, I24, U24, MyInt8, MyUInt8, I32, U32, I64, U64
 
 const BInts = Base.BitInteger_types
 const XInts = (BitIntegers.BitInteger_types..., TestBitIntegers.UInt24, TestBitIntegers.Int24)


### PR DESCRIPTION
For <= 64 bits, this converts to Base's types.
Beyond 64 bits, the generic `hash(x::Real, h::UInt)` method is used, like for `[U]Int128`, but `Base.top_set_bit` has to be specialized to make this fast.

Fix #43.