### PR TITLE
Support for integers with size a non-multiple of 8

### DIFF
--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -533,8 +533,8 @@ function ndigits0zpb(x::XBU, b::Int)
     x == 0 && return 0
     b < 0   && return ndigits0znb(signed(x), b)
     b == 2  && return bitsizeof(x) - leading_zeros(x)
-    b == 8  && return (bitsizeof(x) - leading_zeros(x) + 2) ÷ 3
-    b == 16 && return sizeof(x)<<1 - leading_zeros(x)>>2
+    b == 8  && return cld(bitsizeof(x) - leading_zeros(x), 3)
+    b == 16 && return cld(bitsizeof(x) - leading_zeros(x), 4)
     # b == 10 && return ndigits0z(x) # TODO: implement ndigits0z(x)
 
     d = 0

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -22,17 +22,25 @@ import Base: &, *, +, -, <, <<, <=, ==, >>, >>>, |, ~, AbstractFloat, add_with_o
 
 using Base: GenericIOBuffer, uinttype
 
-using .BSI.Intrinsics: add_int, and_int, ashr_int, bswap_int, checked_sadd_int,
-            checked_sdiv_int, checked_smul_int, checked_srem_int, checked_ssub_int,
-            checked_uadd_int, checked_udiv_int, checked_umul_int, checked_urem_int,
-            checked_usub_int, ctlz_int, ctpop_int, cttz_int, flipsign_int, lshr_int, mul_int,
-            ndigits0z, ndigits0znb, neg_int, not_int, or_int, shl_int, sitofp, sle_int,
-            slt_int, sub_int, uitofp, ule_int, ult_int, xor_int
-
-using Base.GMP: ispos, Limb
-
-using .BSI.Intrinsics: bitcast, checked_trunc_sint, checked_trunc_uint, sext_int,
+using .BSI.Intrinsics: add_int, and_int, ashr_int, bswap_int,
+            checked_sadd_int, checked_sdiv_int, checked_smul_int,
+            checked_srem_int, checked_ssub_int, checked_uadd_int,
+            checked_udiv_int, checked_umul_int, checked_urem_int,
+            checked_usub_int, ctlz_int, ctpop_int, cttz_int,
+            flipsign_int, lshr_int, mul_int, ndigits0z, ndigits0znb,
+            neg_int, not_int, or_int, shl_int, sitofp, sle_int,
+            slt_int, sub_int, uitofp, ule_int, ult_int, xor_int,
+            bitcast, checked_trunc_sint, checked_trunc_uint, sext_int,
             trunc_int, zext_int
+
+using Base.GMP: Limb
+
+if isdefined(Base, :ispositive)
+    const ispos = Base.ispositive
+else
+    using Base.GMP: ispos
+end
+
 
 import Random: rand, Sampler
 using Random: AbstractRNG, Repetition, SamplerType, LessThan, Masked

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -2,13 +2,18 @@
 
 module BitIntegers
 
+include("bitsized/bitsized.jl")
+using .BitSizedIntegers: BitSizedIntegers, Intrinsics
+
 import Base: &, *, +, -, <, <<, <=, ==, >>, >>>, |, ~, AbstractFloat, add_with_overflow,
              bitstring, bswap, checked_abs, count_ones, div, flipsign, hash, isodd, iseven,
              leading_zeros,
              mod, mul_with_overflow, ndigits0zpb, peek, promote_rule, read, rem, signed,
              sub_with_overflow, trailing_zeros, typemax, typemin, unsigned, write, xor
 
-using Base: GenericIOBuffer, add_int, and_int, ashr_int, bswap_int, checked_sadd_int,
+using Base: GenericIOBuffer
+
+using Intrinsics: add_int, and_int, ashr_int, bswap_int, checked_sadd_int,
             checked_sdiv_int, checked_smul_int, checked_srem_int, checked_ssub_int,
             checked_uadd_int, checked_udiv_int, checked_umul_int, checked_urem_int,
             checked_usub_int, ctlz_int, ctpop_int, cttz_int, flipsign_int, lshr_int, mul_int,
@@ -17,7 +22,7 @@ using Base: GenericIOBuffer, add_int, and_int, ashr_int, bswap_int, checked_sadd
 
 using Base.GMP: ispos, Limb
 
-using Core: bitcast, checked_trunc_sint, checked_trunc_uint, sext_int,
+using Intrinsics: bitcast, checked_trunc_sint, checked_trunc_uint, sext_int,
             trunc_int, zext_int
 
 import Random: rand, Sampler

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -40,7 +40,6 @@ using Random: AbstractRNG, Repetition, SamplerType, LessThan, Masked
 export @define_integers
 
 if VERSION >= v"1.4.0-DEV.114"
-#    check_top_bit(::Type{T}, x) where {T} = Core.check_top_bit(T, x)
     check_top_bit(::Type{T}, x) where {T} = BSI.check_top_bit(T, x)
 else
     check_top_bit(::Type{T}, x) where {T} = Core.check_top_bit(x)
@@ -74,6 +73,7 @@ macro define_integers(n::Int, SI=nothing, UI=nothing)
 
     sistr = Symbol(lowercase(string(SI)), :_str)
     uistr = Symbol(lowercase(string(UI)), :_str)
+    # `esc` is necessary only on versions < 1.1
     if n % 8 == 0
         primitive_def = quote
             primitive type $(esc(SI)) <: AbstractBitSigned   $n end
@@ -87,7 +87,6 @@ macro define_integers(n::Int, SI=nothing, UI=nothing)
         end
     end
     quote
-        # `esc` is necessary only on versions < 1.1
         $primitive_def
         Base.Signed(x::$(esc(UI)))   = $(esc(SI))(x)
         Base.Unsigned(x::$(esc(SI))) = $(esc(UI))(x)

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -12,6 +12,8 @@ include("bitsized/bitsized.jl")
 
 using .BitSizedIntegers: BitSizedIntegers as BSI, bitsizeof
 
+export bitsizeof
+
 import Base: &, *, +, -, <, <<, <=, ==, >>, >>>, |, ~, AbstractFloat, add_with_overflow,
              bitstring, bswap, checked_abs, count_ones, div, flipsign, hash, isodd, iseven,
              leading_zeros,

--- a/src/bitsized/bitsized.jl
+++ b/src/bitsized/bitsized.jl
@@ -1,4 +1,5 @@
 module BitSizedIntegers
+
 # export BitSized, SignedBitSized, UnsignedBitSized, @makebitsized
 
 # module for storing bit sized integer types
@@ -17,132 +18,32 @@ abstract type SignedBitSized{N} <: AbstractBitSigned end
 abstract type UnsignedBitSized{N} <: AbstractBitUnsigned end
 BitSized{N} = Union{SignedBitSized{N}, UnsignedBitSized{N}}
 
+bitsizeof(::T) where T = 8sizeof(T)
+bitsizeof(::Type{T}) where T = 8sizeof(T)
+bitsizeof(::BitSized{N}) where N = N
+bitsizeof(::Type{<:BitSized{N}}) where N = N
+
+#=
 function Base.show(io::IO, ::Type{T}) where {N, T<:BitSized{N}}
     prefix = T <: SignedBitSized ? "" : "U"
     print(prefix,"Int",N)
 end
-include("intrinsics.jl")
-import .Intrinsics: Intrinsics
-
-@generated function BitSized{N}(x, ::Type{signed} = Signed) where {N, signed <: Union{Signed,Unsigned}}
-    B = 8cld(N, 8)
-    xN = 8sizeof(x)
-    if signed <: Signed
-        ext = N < xN ? :checked_trunc_sint : :sext_int
-        sym = Symbol(:Int, N)
-    else
-        ext = N < xN ? :checked_trunc_uint : :zext_int
-        sym = Symbol(:UInt, N)
-    end
-    ss = string(sym)
-    quote
-        if isdefined(ITypes, $(QuoteNode(sym))) 
-            Intrinsics.$ext($sym, x)
-        else
-            error($ss, " not defined, run @makebitsized $N")
-        end
-#        Base.llvmcall($code, ITypes.$s, Tuple{Int64}, Int64(x))
-    end
-end
-
-macro makebitsized(N)
-    B = 8cld(N,8)
-    T = Symbol(N isa Signed ? :Int : :UInt, N)
-    M = @__MODULE__
-    (isdefined(ITypes, T) || isdefined(Main, T)) && return :($T)
-    quote
-        @eval ITypes begin
-            (primitive type $T <: SignedBitSized{$N} $B end)
-            $T(x) = BitSized{$N}(x)
-        end
-        @eval $M const $T = ITypes.$T
-#        setglobal!($M, $(esc(QuoteNode(T))), ITypes.$T)
-        const $(esc(T)) = ITypes.$T
-    end
-end
-
-
-#@makebitsized 5
-#@makebitsized 77
-
-@generated function Base.show(io::IO, i::BT) where {N,BT<:SignedBitSized{N}}
-    B = 8sizeof(BT)
-    OB = 2^(64 - leading_zeros(N))
-    T = Symbol(:Int, OB)
-    code = """
-    %3 = trunc i$(B) %0 to i$N
-    %4 = sext i$N %3 to i$OB
-    ret i$OB %4
-    """
-    quote
-        show(io, Base.llvmcall($code, $T, Tuple{BT}, i))
-    end
-end
-
-
-
-@generated function Base.:+(a::T, b::T) where {N, T <: SignedBitSized{N}}
-    s = 8sizeof(T)
-    code = """
-    %3 = trunc i$s %0 to i$N
-    %4 = trunc i$s %1 to i$N
-    %5 = add i$N %3, %4
-    %6 = sext i$N %5 to i$s
-    ret i$s %6
-    """
-    quote
-        Base.llvmcall($code, T, Tuple{T,T}, a, b)
-    end
-end
-
-@generated function Base.:-(a::T, b::T) where {N, T <: SignedBitSized{N}}
-    s = 8sizeof(T)
-    code = """
-    %3 = trunc i$s %0 to i$N
-    %4 = trunc i$s %1 to i$N
-    %5 = sub i$N %3, %4
-    %6 = sext i$N %5 to i$s
-    ret i$s %6
-    """
-    quote
-        Base.llvmcall($code, T, Tuple{T,T}, a, b)
-    end
-end
-
-@generated function Base.:*(a::T, b::T) where {N, T <: SignedBitSized{N}}
-    s = 8sizeof(T)
-    code = """
-    %3 = trunc i$s %0 to i$N
-    %4 = trunc i$s %1 to i$N
-    %5 = mul i$N %3, %4
-    %6 = sext i$N %5 to i$s
-    ret i$s %6
-    """
-    quote
-        Base.llvmcall($code, T, Tuple{T,T}, a, b)
-    end
-end
-
-
-@generated function Base.:-(a::T) where {N, T<:SignedBitSized{N}}
-    s = 8sizeof(T)
-    code = """
-    %3 = trunc i$s %0 to i$N
-    %4 = sub i$N 0, %3
-    %5 = sext i$N %4 to i$s
-    ret i$s %5
-    """
-    quote
-        Base.llvmcall($code, T, Tuple{T}, a)
-    end
-end
-
-#=
-function Base.Int64(x::Int5)
-    Base.llvmcall("""
-    %3 = sext i8 %0 to i64
-    ret i64 %3
-    """, Int64, Tuple{Int5}, x)
-end
 =#
+include("intrinsics.jl")
+import .Intrinsics: Intrinsics, bitsizeof
+
+@generated function is_top_bit_set(x::T) where {N, T<:BitSized{N}}
+    @inline
+    bit = (1%T) << (N-1)
+    :(x & $bit ≠ 0)
+end
+
+function check_top_bit(::Type{To}, x::xT) where {To, xT}
+    @inline 
+    xN = bitsizeof(xT)
+    xN % 8 == 0 && return Core.check_top_bit(To, x)
+    is_top_bit_set(x) && Core.throw_inexacterror(sizeof(x) === sizeof(To) ? :convert : :trunc, To, x)
+    x
+end
+
 end # module BitSizedIntegers

--- a/src/bitsized/bitsized.jl
+++ b/src/bitsized/bitsized.jl
@@ -7,15 +7,14 @@ using ..BitSizedIntegers
 end
 
 import .ITypes: ITypes
-
-
+import ..AbstractBitSigned, ..AbstractBitUnsigned
 #=
 The idea is to round up the storage size to nearest multiple of 8, i.e. whole bytes.
 The unused bits are set to zero.
 =#
 
-abstract type SignedBitSized{N} <: Signed end
-abstract type UnsignedBitSized{N} <: Unsigned end
+abstract type SignedBitSized{N} <: AbstractBitSigned end
+abstract type UnsignedBitSized{N} <: AbstractBitUnsigned end
 BitSized{N} = Union{SignedBitSized{N}, UnsignedBitSized{N}}
 
 function Base.show(io::IO, ::Type{T}) where {N, T<:BitSized{N}}

--- a/src/bitsized/bitsized.jl
+++ b/src/bitsized/bitsized.jl
@@ -49,7 +49,7 @@ end
 function Base.hex(x::BitSized, pad::Int, neg::Bool)
     m = cld(bitsizeof(x) - leading_zeros(x), 4)
     n = neg + max(pad, m)
-    a = Base.StringMemory(n)
+    a = VERSION < v"1.11" ? Base.StringVector(n) : Base.StringMemory(n)
     i = n
     while i >= 2
         b = (x % UInt8)::UInt8
@@ -64,7 +64,11 @@ function Base.hex(x::BitSized, pad::Int, neg::Bool)
         @inbounds a[i] = d + ifelse(d > 0x9, 0x57, 0x30)
     end
     neg && (@inbounds a[1] = 0x2d) # UInt8('-')
-    Base.unsafe_takestring(a)
+    if VERSION < v"1.12"
+        String(a)
+    else
+        Base.unsafe_takestring(a)
+    end
 end
 
 

--- a/src/bitsized/bitsized.jl
+++ b/src/bitsized/bitsized.jl
@@ -1,0 +1,149 @@
+module BitSizedIntegers
+# export BitSized, SignedBitSized, UnsignedBitSized, @makebitsized
+
+# module for storing bit sized integer types
+module ITypes
+using ..BitSizedIntegers
+end
+
+import .ITypes: ITypes
+
+
+#=
+The idea is to round up the storage size to nearest multiple of 8, i.e. whole bytes.
+The unused bits are set to zero.
+=#
+
+abstract type SignedBitSized{N} <: Signed end
+abstract type UnsignedBitSized{N} <: Unsigned end
+BitSized{N} = Union{SignedBitSized{N}, UnsignedBitSized{N}}
+
+function Base.show(io::IO, ::Type{T}) where {N, T<:BitSized{N}}
+    prefix = T <: SignedBitSized ? "" : "U"
+    print(prefix,"Int",N)
+end
+include("intrinsics.jl")
+import .Intrinsics: Intrinsics
+
+@generated function BitSized{N}(x, ::Type{signed} = Signed) where {N, signed <: Union{Signed,Unsigned}}
+    B = 8cld(N, 8)
+    xN = 8sizeof(x)
+    if signed <: Signed
+        ext = N < xN ? :checked_trunc_sint : :sext_int
+        sym = Symbol(:Int, N)
+    else
+        ext = N < xN ? :checked_trunc_uint : :zext_int
+        sym = Symbol(:UInt, N)
+    end
+    ss = string(sym)
+    quote
+        if isdefined(ITypes, $(QuoteNode(sym))) 
+            Intrinsics.$ext($sym, x)
+        else
+            error($ss, " not defined, run @makebitsized $N")
+        end
+#        Base.llvmcall($code, ITypes.$s, Tuple{Int64}, Int64(x))
+    end
+end
+
+macro makebitsized(N)
+    B = 8cld(N,8)
+    T = Symbol(N isa Signed ? :Int : :UInt, N)
+    M = @__MODULE__
+    (isdefined(ITypes, T) || isdefined(Main, T)) && return :($T)
+    quote
+        @eval ITypes begin
+            (primitive type $T <: SignedBitSized{$N} $B end)
+            $T(x) = BitSized{$N}(x)
+        end
+        @eval $M const $T = ITypes.$T
+#        setglobal!($M, $(esc(QuoteNode(T))), ITypes.$T)
+        const $(esc(T)) = ITypes.$T
+    end
+end
+
+
+#@makebitsized 5
+#@makebitsized 77
+
+@generated function Base.show(io::IO, i::BT) where {N,BT<:SignedBitSized{N}}
+    B = 8sizeof(BT)
+    OB = 2^(64 - leading_zeros(N))
+    T = Symbol(:Int, OB)
+    code = """
+    %3 = trunc i$(B) %0 to i$N
+    %4 = sext i$N %3 to i$OB
+    ret i$OB %4
+    """
+    quote
+        show(io, Base.llvmcall($code, $T, Tuple{BT}, i))
+    end
+end
+
+
+
+@generated function Base.:+(a::T, b::T) where {N, T <: SignedBitSized{N}}
+    s = 8sizeof(T)
+    code = """
+    %3 = trunc i$s %0 to i$N
+    %4 = trunc i$s %1 to i$N
+    %5 = add i$N %3, %4
+    %6 = sext i$N %5 to i$s
+    ret i$s %6
+    """
+    quote
+        Base.llvmcall($code, T, Tuple{T,T}, a, b)
+    end
+end
+
+@generated function Base.:-(a::T, b::T) where {N, T <: SignedBitSized{N}}
+    s = 8sizeof(T)
+    code = """
+    %3 = trunc i$s %0 to i$N
+    %4 = trunc i$s %1 to i$N
+    %5 = sub i$N %3, %4
+    %6 = sext i$N %5 to i$s
+    ret i$s %6
+    """
+    quote
+        Base.llvmcall($code, T, Tuple{T,T}, a, b)
+    end
+end
+
+@generated function Base.:*(a::T, b::T) where {N, T <: SignedBitSized{N}}
+    s = 8sizeof(T)
+    code = """
+    %3 = trunc i$s %0 to i$N
+    %4 = trunc i$s %1 to i$N
+    %5 = mul i$N %3, %4
+    %6 = sext i$N %5 to i$s
+    ret i$s %6
+    """
+    quote
+        Base.llvmcall($code, T, Tuple{T,T}, a, b)
+    end
+end
+
+
+@generated function Base.:-(a::T) where {N, T<:SignedBitSized{N}}
+    s = 8sizeof(T)
+    code = """
+    %3 = trunc i$s %0 to i$N
+    %4 = sub i$N 0, %3
+    %5 = sext i$N %4 to i$s
+    ret i$s %5
+    """
+    quote
+        Base.llvmcall($code, T, Tuple{T}, a)
+    end
+end
+
+#=
+function Base.Int64(x::Int5)
+    Base.llvmcall("""
+    %3 = sext i8 %0 to i64
+    ret i64 %3
+    """, Int64, Tuple{Int5}, x)
+end
+=#
+end # module BitSizedIntegers

--- a/src/bitsized/intrinsics.jl
+++ b/src/bitsized/intrinsics.jl
@@ -1,0 +1,532 @@
+module Intrinsics
+import ..BitSized 
+
+#=
+We need to make intrinsics aware of bit sized integers.
+But for some of them we can use the ones from core. Those
+that don't care about the unused bits. 
+=#
+
+const intrinsics = (:add_int, :and_int, :ashr_int, :bswap_int,
+                    :checked_sadd_int, :checked_sdiv_int,
+                    :checked_smul_int, :checked_srem_int,
+                    :checked_ssub_int, :checked_uadd_int,
+                    :checked_udiv_int, :checked_umul_int,
+                    :checked_urem_int, :checked_usub_int, :ctlz_int,
+                    :ctpop_int, :cttz_int, :flipsign_int, :lshr_int,
+                    :mul_int, :ndigits0z, :ndigits0znb, :neg_int,
+                    :not_int, :or_int, :shl_int, :sitofp, :sle_int,
+                    :slt_int, :sub_int, :uinttype, :uitofp, :ule_int,
+                    :ult_int, :xor_int)
+
+bitsizeof(::T) where T = 8sizeof(T)
+bitsizeof(::Type{T}) where T = 8sizeof(T)
+bitsizeof(::BitSized{N}) where N = N
+bitsizeof(::Type{<:BitSized{N}}) where N = N
+
+onearg = (:ctlz_int, :ctpop_int, :neg_int, :not_int, :bswap_int, 
+          :uinttype)
+
+twoarg = (:add_int, :and_int, :ashr_int, :checked_sadd_int,
+           :checked_sdiv_int, :checked_smul_int, :checked_srem_int,
+           :checked_ssub_int, :checked_uadd_int, :checked_udiv_int,
+           :checked_umul_int, :checked_urem_int, :checked_usub_int,
+           :flipsign_int, :lshr_int, :mul_int, :ndigits0z,
+           :ndigits0znb, :or_int, :shl_int, :sitofp, :sle_int,
+           :slt_int, :sub_int, :uitofp, :ule_int, :ult_int, :xor_int,
+           :checked_trunc_sint, :checked_trunc_uint,
+           :bitcast, :sext_int, :trunc_int, :zext_int)
+
+#=
+bitcast, checked_trunc_sint, checked_trunc_uint, sext_int,
+            trunc_int, zext_int
+=#
+for F in twoarg
+    @eval $F(x,y) = Core.Intrinsics.$F(x,y)
+end
+
+for F in onearg
+    @eval $F(x) = Core.Intrinsics.$F(x)
+end
+
+for F in (onearg..., twoarg...)
+    @eval $F(x::BitSized...) = error("Unimplemented intrinsic ", $F)
+end
+
+function checked_trunc_sint(::Type{To}, x::From) where {To,From}
+    @inline
+    y = trunc_int(To, x)
+    back = sext_int(From, y)
+    Core.Intrinsics.eq_int(x, back) || Core.throw_inexacterror(:trunc, To, x)
+    y
+end
+
+function checked_trunc_uint(::Type{To}, x::From) where {To,From}
+    @inline
+    y = trunc_int(To, x)
+    back = zext_int(From, y)
+    Core.Intrinsics.eq_int(x, back) || Core.throw_inexacterror(:trunc, To, x)
+    y
+end
+
+
+
+@generated function typemin(::Type{T}) where {N,T<:BitSized{N}}
+    S = 8sizeof(T)
+    code = """
+    %2 = shl i$N 1, $(N-1)
+    %3 = zext i$N %2 to i$S
+    ret i$S %3
+    """
+    quote
+        Base.llvmcall($code, T, Tuple{})
+    end
+end
+
+@generated function typemax(::Type{T}) where {N, T<:BitSized{N}}
+    S = 8sizeof(T)
+    if T <: Signed
+        code = """
+        %2 = zext i$(N-1) -1 to i$S
+        ret i$S %2
+        """
+    else
+        code = """
+        %3 = zext i$N -1 to i$S
+        ret i$S %3
+        """
+    end
+    quote
+        Base.llvmcall($code, T, Tuple{})
+    end
+end
+
+
+# arith and logic, two args
+for F in (:add, :and, :mul, :or, :sub, :xor)
+    ifun = Symbol(F, "_int")
+    ex = quote
+        @generated function $ifun(x::T,y::T) where {N, T<:BitSized{N}}
+            S = 8sizeof(T)
+            F = $(QuoteNode(F))
+            code =     """
+            %3 = trunc i$S %0 to i$N
+            %4 = trunc i$S %1 to i$N
+            %5 = $F i$N %3, %4
+            %6 = zext i$N %5 to i$S
+            ret i$S %6
+            """
+
+            quote
+                Base.llvmcall($code, T, Tuple{T,T}, x, y)
+            end
+        end
+    end
+    @eval $ex
+end
+
+# arith comp
+for F in (:sle, :slt, :ule, :ult)
+    ifun = Symbol(F, "_int")
+    ex = quote
+        @generated function $ifun(x::T, y::T) where {N, T<:BitSized{N}}
+            S = 8sizeof(T)
+            F = $(QuoteNode(F))
+            code = """
+            %3 = trunc i$S %0 to i$N
+            %4 = trunc i$S %1 to i$N
+            %5 = icmp $F i$N %3, %4
+            %6 = zext i1 %5 to i8
+            ret i8 %6
+            """
+            quote
+                Base.llvmcall($code, Bool, Tuple{T,T}, x, y)
+            end
+        end
+    end
+    @eval $ex
+end
+
+
+# bit counts
+for F in (:ctlz, :ctpop, :cttz)
+    ifun = Symbol(F, "_int")
+    ex = quote
+        @generated function $ifun(x::T) where {N, T<:BitSized{N}}
+            S = 8sizeof(T)
+            is = Sys.WORD_SIZE
+            F = $(QuoteNode(F))
+            code = """
+            %3 = trunc i$S %0 to i$N
+            %4 = call i$N @llvm.$F.i$N(i$N %3)
+            %5 = zext i$N %4 to i$is
+            ret i$is %5
+            """
+            quote
+                Base.llvmcall($code, Int, Tuple{T}, x)
+            end
+        end
+    end
+    @eval $ex
+end
+
+# checked arith
+for F in (:sadd, :smul, :ssub, :uadd, :umul, :usub)
+    ifun = Symbol("checked_",F, "_int")
+    ex = quote
+        @generated function $ifun(x::T, y::T) where {N, T<:BitSized{N}}
+            S = 8sizeof(T)
+            F = $(QuoteNode(F))
+            # Tuple{Int8, Bool} is taken by llvmcall to be [2 x i8], not {i8, i8}
+            rettype = S == 8 ? "[2 x i8]" : "{i$S, i8}"
+            code = """
+            %3 = trunc i$S %0 to i$N
+            %4 = trunc i$S %1 to i$N
+            %5 = call {i$N, i1} @llvm.$F.with.overflow.i$N(i$N %3, i$N %4)
+            %6 = extractvalue { i$N, i1} %5, 0
+            %7 = extractvalue { i$N, i1} %5, 1
+            %flag = zext i1 %7 to i8
+            %z = zext i$N %6 to i$S
+            %9 = insertvalue $rettype zeroinitializer, i$S %z, 0
+            %10 = insertvalue $rettype %9, i8 %flag, 1
+            ret $rettype %10
+            """
+            quote
+                Base.llvmcall($code, Tuple{T, Bool}, Tuple{T,T}, x, y)
+            end
+        end
+    end
+    @eval $ex
+end
+
+
+# checked sdiv
+@generated function checked_sdiv_int(x::T, y::T) where {N, T<:BitSized{N}}
+    S = 8sizeof(T)
+    M = @__MODULE__
+    llvmname = string(M, ".check_sdiv_int", S)
+    io = IOBuffer()
+    show(io, typemin(T))
+    tmin = String(take!(io))
+    println("tmin: ",tmin)
+    code = ("""
+    declare void @ijl_throw(ptr)
+    declare ptr @jl_diverror_exception()
+    define i$S @$llvmname(i$S %x, i$S %y) {
+      %num = trunc i$S %x to i$N
+      %denom = trunc i$S %y to i$N
+      %1 = icmp ne i$N %num, $tmin
+      %2 = icmp ne i$N %denom, -1
+      %3 = or i1 %1, %2
+      %4 = icmp ne i$N %denom, 0
+      %valid = and i1 %4, %3
+      br i1 %valid, label %pass, label %fail
+    fail:
+      %exc = load ptr, ptr @jl_diverror_exception, align 8
+      call void @ijl_throw(ptr nonnull %exc)
+      unreachable
+    pass:
+      %q = sdiv i$N %num, %denom
+      %r = zext i$N %q to i$S
+      ret i$S %r
+    }
+    """, llvmname)
+    println(code[1])
+    quote
+        Base.llvmcall($code, T, Tuple{T,T}, x, y)
+    end
+end
+
+# checked srem
+
+@generated function checked_srem_int(x::T, y::T) where {N, T<:BitSized{N}}
+    S = 8sizeof(T)
+    llvmname = string(@__MODULE__, ".checked_srem_int", S)
+    code = ("""
+         declare void @ijl_throw(ptr)
+         declare ptr @jl_diverror_exception()
+         define i$S @$llvmname(i$S %x, i$S %y) {
+          top:
+            %num = trunc i$S %x to i$N
+            %denom = trunc i$S %y to i$N
+            switch i$N %denom, label %oksrem [
+              i$N 0, label %fail
+              i$N -1, label %after_srem
+            ]
+          fail:
+            %exc = load ptr, ptr @jl_diverror_exception, align 8
+            call void @ijl_throw(ptr nonnull %exc)
+            unreachable
+          oksrem:
+            %rem = srem i$N %num, %denom
+            br label %after_srem
+          after_srem:
+            %res = phi i$N [ %rem, %oksrem ], [ 0, %top]
+            %ret = zext i$N %res to i$S
+            ret i$S %ret
+         }
+    """, llvmname)
+    quote
+        Base.llvmcall($code, T, Tuple{T,T}, x, y)
+    end
+end
+
+for F in (:udiv, :urem)
+    fname = Symbol("checked_",F,"_int")
+    ex = quote
+        @generated function $fname(x::T, y::T) where {N, T<:BitSized{N}}
+            S = 8sizeof(T)
+            llvmname = string(@__MODULE__, ".",$fname, S)
+            op = $(QuoteNode(F))
+            definecode = ("""
+              declare void @ijl_throw(ptr)
+              declare ptr @jl_diverror_exception()
+              define i$S @$llvmname(i$S %x, i$S %y) {
+                %num = trunc i$S %x to i$N
+                %denom = trunc i$S %y to i$N
+                %divby0 = icmp eq i$N %denom, 0
+                br i1 %divby0, label %fail, label %pass
+               fail:
+                %exc = load ptr, ptr @jl_diverror_exception, align 8
+                call void @ijl_throw(ptr nonnull %exc)
+                unreachable
+               pass:
+                %result = $op i$N %num, %denom
+                %ret = zext i$N %result to i$S
+                ret i$S %ret
+              }
+     """, llvmname)
+            quote
+                Base.llvmcall($definecode, T, Tuple{T,T}, x, y)
+            end
+        end
+    end
+    @eval $ex
+end
+
+
+# what's left
+#=
+(
+ :ndigits0z, :ndigits0znb, 
+ :uinttype)
+
+bitcast, sext_int,
+            trunc_int, zext_int
+
+    %2 = shl i$N 1, $(N-1)
+    %3 = $ext i$N %2 to i$S
+    ret i$S %3
+
+=#
+
+function trunc_int(::Type{RT}, x::T) where {RT, T}
+    RT <: BitSized || T <: BitSized || return Core.Intrinsics.trunc_int(RT, x)
+    _trunc_int(RT, x)
+end
+
+@generated function _trunc_int(::Type{RT}, x::T) where {RT, T}
+    RN = bitsizeof(RT)
+    N = bitsizeof(T)
+    N == RN && return :(Core.Intrinsics.trunc_int(RT, x))
+    N < RN && error("SExt: output bitsize must be > input bitsize")
+    (N % 8) == (RN % 8) == 0 && return :(Core.Intrinsics.trunc_int(RT, x))
+    S = 8sizeof(T)
+    RS = 8sizeof(RT)
+
+    prep = N == S ? "%x = or i$N %0, 0" : "%x = trunc i$S %0 to i$N"
+    zext = N == RS ? "%ret = or i$N %x, 0" :
+        N < RS ? "%ret = zext i$N %x to i$RS" :
+        "%ret = trunc i$N %x to i$RS"
+    code = """
+         $prep
+         $zext
+         ret i$RS %ret
+    """
+    quote
+        Base.llvmcall($code, RT, Tuple{T}, x)
+    end
+end
+
+function sext_int(::Type{RT}, x::T) where {RT, T}
+    RT <: BitSized || T <: BitSized || return Core.Intrinsics.sext_int(RT, x)
+    _sext_int(RT, x)
+end
+
+@generated function _sext_int(::Type{RT}, x::T) where {RT, T}
+    RN = bitsizeof(RT)
+    N = bitsizeof(T)
+    (N % 8) == (RN % 8) == 0 && return Core.Intrinsics.sext_int(RT, x)
+    N == RN && return Core.Intrinsics.sext_int(RT, x)
+    RN ≤ N && error("SExt: output bitsize must be > input bitsize")
+    S = 8sizeof(T)
+    RS = 8sizeof(RT)
+    prep = S == N ? "%x = or i$S %0, 0" : "%x = trunc i$S %0 to i$N"
+    ext = N == RN ? "%r.0 = or i$x %x, 0" : "%r.0 = sext i$N %x to i$RN"
+    zext = RN == RS ? "%r = or i$RN %r.0, 0" : "%r = zext i$RN %r.0 to i$RS"
+    ret = "ret i$RS %r"
+    code = join((prep, ext, zext, ret), "\n")
+    quote
+        Base.llvmcall($code, RT, Tuple{T}, x)
+    end
+end
+
+
+function zext_int(::Type{RT}, x::T) where {RT, T}
+    RT <: BitSized || T <: BitSized || return Core.Intrinsics.zext_int(RT, x)
+    _zext_int(RT, x)
+end
+
+@generated function _zext_int(::Type{RT}, x::T) where {RT, T}
+    RN = bitsizeof(RT)
+    N = bitsizeof(T)
+    N % 8 == RN % 8 == 0 && return Core.Intrinsics.sext_int(RT, x)
+    RN ≤ N && error("ZExt: output bitsize must be > input bitsize")
+    S = 8sizeof(T)
+    RS = 8sizeof(RT)
+    prep = S == N ? "%x = %0" : "%x = trunc i$S %0 to i$N"
+    ext = N == RN ? "%r.0 = or i$x %x, 0" : "%r.0 = zext i$N %x to i$RN"
+    zext = RN == RS ? "%r = or i$RN %r.0, 0" : "%r = zext i$RN %r.0 to i$RS"
+    ret = "ret i$RS %r"
+    code = join((prep, ext, zext, ret), "\n")
+
+    quote
+        Base.llvmcall($code, RT, Tuple{T}, x)
+    end
+end
+
+
+
+bitcast(::Type{RT}, x::T) where {RT, N, T<:BitSized{N}} = reinterpret(RT, x)
+
+
+
+for F in (:sitofp, :uitofp)
+    ex = quote
+        @generated function $F(::Type{FT}, x::T) where {FT<:Union{Float16,Float32,Float64}, N, T<:BitSized{N}}
+            S = 8sizeof(T)
+            op = $(QuoteNode(F))
+            ft = FT<:Float16 ? "half" :
+                FT <: Float32 ? "float" :
+                "double"
+
+            code = """
+            %x = trunc i$S %0 to i$N
+            %ret = $op i$N %x to $ft
+            ret $ft %ret
+            """
+            quote
+                Base.llvmcall($code, FT, Tuple{T}, x)
+            end
+        end
+    end
+    @eval $ex
+end
+
+
+@generated function bswap_int(x::T) where {N, T<:BitSized{N}}
+    S = 8sizeof(T)
+    code = """
+       %x = trunc i$S %0 to i$N
+       %r = call i$N @llvm.bswap.i$N(i$N %x)
+       %ret = zext i$N %r to i$S
+       ret i$S %ret
+    """
+    quote
+        Base.llvmcall($code, T, Tuple{T}, x)
+    end
+end
+
+
+@generated function shl_int(x::T, y::T) where {N, T<:BitSized{N}}
+    S = 8sizeof(T)
+    code = """
+       %x = trunc i$S %0 to i$N
+       %y = trunc i$S %1 to i$N
+       %3 = shl i$N %x, %y
+;       %4 = icmp ugt i$N %y, $(N-1)
+;       %r = select i1 %4, i$N 0, i$N %3
+       %ret = zext i$N %3 to i$S
+       ret i$S %ret
+    """
+    quote
+        Base.llvmcall($code, T, Tuple{T,T}, x, y)
+    end
+end
+
+@generated function neg_int(x::T) where {N, T<:BitSized{N}}
+    S = 8sizeof(T)
+    code = """
+       %x = trunc i$S %0 to i$N
+       %r = sub i$N 0, %x
+       %ret = zext i$N %r to i$S
+       ret i$S %ret
+    """
+    quote
+        Base.llvmcall($code, T, Tuple{T}, x)
+    end
+end
+
+@generated function not_int(x::T) where {N, T<:BitSized{N}}
+    S = 8sizeof(T)
+    code = """
+       %x = trunc i$S %0 to i$N
+       %r = xor i$N %x, -1
+       %ret = zext i$N %r to i$S
+       ret i$S %ret
+    """
+    quote
+        Base.llvmcall($code, T, Tuple{T}, x)
+    end
+end
+
+
+# arith shift right
+@generated function ashr_int(x::T, y::T) where {N, T<:BitSized{N}}
+    S = 8sizeof(T)
+    code = """
+       %x = trunc i$S %0 to i$N
+       %y = trunc i$S %1 to i$N
+       %v = call i$N @llvm.umin.i$N(i$N %y, i$N $(N-1))
+       %r = ashr i$N %x, %v
+       %ret = zext i$N %r to i$S
+       ret i$S %ret
+    """
+    quote
+        Base.llvmcall($code, T, Tuple{T,T}, x, y)
+    end
+end
+
+@generated function flipsign_int(x::T, y::T) where {N, T<:BitSized{N}}
+    S = 8sizeof(T)
+    code = """
+       %x = trunc i$S %0 to i$N
+       %y = trunc i$S %1 to i$N
+       %v = ashr i$N %y, $(N-1)
+       %3 = add i$N %v, %x
+       %r = xor i$N %3, %v
+       %ret = zext i$N %r to i$S
+       ret i$S %ret
+    """
+    quote
+        Base.llvmcall($code, T, Tuple{T,T}, x, y)
+    end
+end
+
+@generated function lshr_int(x::T, y::T) where {N, T<:BitSized{N}}
+    S = 8sizeof(T)
+    code = """
+       %x = trunc i$S %0 to i$N
+       %y = trunc i$S %1 to i$N
+       %s = lshr i$N %x, %y
+       %t = icmp ugt i$N %y, $(N-1)
+       %r = select i1 %t, i$N 0, i$N %s
+       %ret = zext i$N %r to i$S
+       ret i$S %ret
+    """
+    quote
+        Base.llvmcall($code, T, Tuple{T,T}, x, y)
+    end
+end
+
+end  # module Intrinsics

--- a/src/bitsized/intrinsics.jl
+++ b/src/bitsized/intrinsics.jl
@@ -24,8 +24,7 @@ bitsizeof(::Type{T}) where T = 8sizeof(T)
 bitsizeof(::BitSized{N}) where N = N
 bitsizeof(::Type{<:BitSized{N}}) where N = N
 
-onearg = (:ctlz_int, :ctpop_int, :neg_int, :not_int, :bswap_int, 
-          :uinttype)
+onearg = (:ctlz_int, :ctpop_int, :neg_int, :not_int, :bswap_int)
 
 twoarg = (:add_int, :and_int, :ashr_int, :checked_sadd_int,
            :checked_sdiv_int, :checked_smul_int, :checked_srem_int,
@@ -71,7 +70,7 @@ end
 
 
 
-@generated function typemin(::Type{T}) where {N,T<:BitSized{N}}
+@generated function Base.typemin(::Type{T}) where {N,T<:BitSized{N}}
     S = 8sizeof(T)
     code = """
     %2 = shl i$N 1, $(N-1)
@@ -83,7 +82,7 @@ end
     end
 end
 
-@generated function typemax(::Type{T}) where {N, T<:BitSized{N}}
+@generated function Base.typemax(::Type{T}) where {N, T<:BitSized{N}}
     S = 8sizeof(T)
     if T <: Signed
         code = """
@@ -208,7 +207,6 @@ end
     io = IOBuffer()
     show(io, typemin(T))
     tmin = String(take!(io))
-    println("tmin: ",tmin)
     code = ("""
     declare void @ijl_throw(ptr)
     declare ptr @jl_diverror_exception()
@@ -231,7 +229,7 @@ end
       ret i$S %r
     }
     """, llvmname)
-    println(code[1])
+
     quote
         Base.llvmcall($code, T, Tuple{T,T}, x, y)
     end

--- a/src/bitsized/intrinsics.jl
+++ b/src/bitsized/intrinsics.jl
@@ -7,9 +7,9 @@ But for some of them we can use the ones from core. Those
 that don't care about the unused bits.
 =#
 
-onearg = (:ctlz_int, :ctpop_int, :cttz_int, :neg_int, :not_int, :bswap_int)
+const onearg = (:ctlz_int, :ctpop_int, :cttz_int, :neg_int, :not_int, :bswap_int)
 
-twoarg = (:add_int, :and_int, :ashr_int, :checked_sadd_int,
+const twoarg = (:add_int, :and_int, :ashr_int, :checked_sadd_int,
            :checked_sdiv_int, :checked_smul_int, :checked_srem_int,
            :checked_ssub_int, :checked_uadd_int, :checked_udiv_int,
            :checked_umul_int, :checked_urem_int, :checked_usub_int,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -345,14 +345,15 @@ end
 
 
 @testset "ndigits0z" begin
-    base = rand([-100:-2; 2:200])
-    for X in XInts
-        x = rand(X)
-        if X <: Unsigned && base < 0
-            x >>= 1 # ndigits0znb not implemented in this case
+    for base in [-100:-2; 2:200]
+        for X in XInts
+            x = rand(X)
+            if X <: Unsigned && base < 0
+                x >>= 1 # ndigits0znb not implemented in this case
+            end
+            n = big(x)
+            @test Base.ndigits0z(x, base) == Base.ndigits0z(n, base)
         end
-        n = big(x)
-        @test Base.ndigits0z(x, base) == Base.ndigits0z(n, base)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -449,7 +449,7 @@ end
 
 @testset "checked operations" begin
     for X in XInts
-        if sizeof(X) != 3 # bug with [U]Int24, cf. Julia issue #34288
+        if bitsizeof(X) != 24 # bug with [U]Int24, cf. Julia issue #34288
             @test Base.sub_with_overflow(typemin(X)+X(3), X(3)) == (typemin(X), false)
             @test Base.sub_with_overflow(typemin(X)+X(2), X(3)) == (typemax(X), true)
             @test Base.add_with_overflow(typemax(X)-X(3), X(3)) == (typemax(X), false)

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -14,6 +14,7 @@ using BitIntegers, Test
 @define_integers 200
 @define_integers 8  MyInt8 MyUInt8
 @define_integers 25
+@define_integers 257
 
 # only for specific tests:
 @define_integers 32 I32 U32
@@ -44,10 +45,11 @@ end
 
 end # module TestBitIntegers ##################################################
 
-using .TestBitIntegers: Int24, UInt24, I24, U24, MyInt8, MyUInt8, I32, U32, I64, U64, Int25, UInt25
+using .TestBitIntegers: Int24, UInt24, I24, U24, MyInt8, MyUInt8, I32, U32, I64, U64
 
 const BInts = Base.BitInteger_types
-const XInts = (BitIntegers.BitInteger_types..., TestBitIntegers.UInt24, TestBitIntegers.Int24, Int25, UInt25)
+const XInts = (BitIntegers.BitInteger_types..., TestBitIntegers.UInt24, TestBitIntegers.Int24,
+               TestBitIntegers.Int25, TestBitIntegers.UInt25, TestBitIntegers.Int257, TestBitIntegers.UInt257)
 const Ints = (BInts..., XInts...)
 
 # we don't include most Base-only type combinations:

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -13,6 +13,7 @@ using BitIntegers, Test
 @define_integers 24 I24 U24 # to test mixed operations with Int24
 @define_integers 200
 @define_integers 8  MyInt8 MyUInt8
+@define_integers 25
 
 # only for specific tests:
 @define_integers 32 I32 U32
@@ -43,10 +44,10 @@ end
 
 end # module TestBitIntegers ##################################################
 
-using .TestBitIntegers: Int24, UInt24, I24, U24, MyInt8, MyUInt8, I32, U32, I64, U64
+using .TestBitIntegers: Int24, UInt24, I24, U24, MyInt8, MyUInt8, I32, U32, I64, U64, Int25, UInt25
 
 const BInts = Base.BitInteger_types
-const XInts = (BitIntegers.BitInteger_types..., TestBitIntegers.UInt24, TestBitIntegers.Int24)
+const XInts = (BitIntegers.BitInteger_types..., TestBitIntegers.UInt24, TestBitIntegers.Int24, Int25, UInt25)
 const Ints = (BInts..., XInts...)
 
 # we don't include most Base-only type combinations:


### PR DESCRIPTION
Integers like `Int7` and `Int53` are supported via `llvmcall`. 
The storage size, the size of the primitive type, is the next multiple of 8.

At some point in time, julia might support this with `primitive type`, the transition to that should be reasonably easy.
