### PR TITLE
fix use of `Base.GMP.ispos` (removed in Julia v1.13)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BitIntegers"
 uuid = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 authors = ["Rafael Fourquet <fourquet.rafael@gmail.com>"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This package is implemented using `primitive type` and julia intrinsics, the cav
 not always be legal (e.g. in some julia versions, `Primes.factor(rand(UInt256))` used to
 make LLVM abort the program, while it was fine for `Int256`).
 
-There are another couple of outstanding issues:
+There were another couple of outstanding issues in older Julia versions:
 
 1) prior to Julia version 1.11: the intrinsics for division operations used to make LLVM fail for widths
 greater than 128 bits,
@@ -54,6 +54,11 @@ https://github.com/JuliaLang/julia/pull/33283).
 
 
 ## Release notes
+
+### v0.3.6
+
+* `unsigned` and `signed` can be called on all integer types ([#2](https://github.com/rfourquet/BitIntegers.jl/pull/2))
+* fix use of `Base.GMP.ispos` (removed in Julia v1.13) ([#58](https://github.com/rfourquet/BitIntegers.jl/pull/58))
 
 ### v0.3.5
 

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -15,7 +15,7 @@ using Base: GenericIOBuffer, add_int, and_int, ashr_int, bswap_int, checked_sadd
             ndigits0z, ndigits0znb, neg_int, not_int, or_int, shl_int, sitofp, sle_int,
             slt_int, sub_int, uinttype, uitofp, ule_int, ult_int, xor_int
 
-using Base.GMP: ispos, Limb
+using Base.GMP: Limb
 
 using Core: bitcast, checked_trunc_sint, checked_trunc_uint, sext_int,
             trunc_int, zext_int
@@ -37,6 +37,12 @@ end
 
 if VERSION >= v"1.5"
     import Base: bitrotate
+end
+
+if isdefined(Base.GMP, :ispos)
+    ispos(x) = Base.GMP.ispos(x)
+else
+    ispos(x) = Base.ispositive(x)
 end
 
 


### PR DESCRIPTION
Fix #56.