### PR TITLE
fix `mul_with_overflow` for unsigned types larger than 16 bytes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BitIntegers"
 uuid = "c3b6d118-76ef-56ca-8cc7-ebb389d030a1"
 authors = ["Rafael Fourquet <fourquet.rafael@gmail.com>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ https://github.com/JuliaLang/julia/pull/33283).
 
 ## Release notes
 
+### v0.3.7
+
+*  fix `mul_with_overflow` for unsigned types larger than 16 bytes ([#59](https://github.com/rfourquet/BitIntegers.jl/pull/59))
+
 ### v0.3.6
 
 * `unsigned` and `signed` can be called on all integer types ([#2](https://github.com/rfourquet/BitIntegers.jl/pull/2))

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -482,8 +482,10 @@ add_with_overflow(x::T, y::T) where {T<:XBU} = checked_uadd_int(x, y)
 sub_with_overflow(x::T, y::T) where {T<:XBS} = checked_ssub_int(x, y)
 sub_with_overflow(x::T, y::T) where {T<:XBU} = checked_usub_int(x, y)
 
-mul_with_overflow(x::T, y::T) where {T<:XBS} = sizeof(T) >= 16 ? broken_mul_with_overflow(x, y) : checked_smul_int(x, y)
-mul_with_overflow(x::T, y::T) where {T<:XBU} = sizeof(T) >= 16 ? broken_mul_with_overflow(x, y) : checked_umul_int(x, y)
+mul_with_overflow(x::T, y::T) where {T<:XBS} =
+    (sizeof(T) > 16 && VERSION < v"1.11-") ? broken_mul_with_overflow(x, y) : checked_smul_int(x, y)
+mul_with_overflow(x::T, y::T) where {T<:XBU} =
+    (sizeof(T) > 16 && VERSION < v"1.11-") ? broken_mul_with_overflow(x, y) : checked_umul_int(x, y)
 
 # cf. base/checked.jl
 # TODO: check whether the specific implementation for [U]Int128 is better suited here

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -483,9 +483,9 @@ sub_with_overflow(x::T, y::T) where {T<:XBS} = checked_ssub_int(x, y)
 sub_with_overflow(x::T, y::T) where {T<:XBU} = checked_usub_int(x, y)
 
 mul_with_overflow(x::T, y::T) where {T<:XBS} =
-    (sizeof(T) > 16 && VERSION < v"1.11-") ? broken_mul_with_overflow(x, y) : checked_smul_int(x, y)
+    (sizeof(T) >= 16 && VERSION < v"1.11-") ? broken_mul_with_overflow(x, y) : checked_smul_int(x, y)
 mul_with_overflow(x::T, y::T) where {T<:XBU} =
-    (sizeof(T) > 16 && VERSION < v"1.11-") ? broken_mul_with_overflow(x, y) : checked_umul_int(x, y)
+    (sizeof(T) >= 16 && VERSION < v"1.11-") ? broken_mul_with_overflow(x, y) : checked_umul_int(x, y)
 
 # cf. base/checked.jl
 # TODO: check whether the specific implementation for [U]Int128 is better suited here
@@ -495,13 +495,11 @@ function broken_mul_with_overflow(x::T, y::T) where T<:XBS
     r % T, f
 end
 
-#= broken
 function broken_mul_with_overflow(x::T, y::T) where T<:XBU
     r = widemul(x, y)
     f = r % T != r
     r % T, f
 end
-=#
 
 function checked_abs(x::XBS)
     r = ifelse(x<0, -x, x)

--- a/src/BitIntegers.jl
+++ b/src/BitIntegers.jl
@@ -495,11 +495,13 @@ function broken_mul_with_overflow(x::T, y::T) where T<:XBS
     r % T, f
 end
 
+#= broken
 function broken_mul_with_overflow(x::T, y::T) where T<:XBU
     r = widemul(x, y)
     f = r % T != r
     r % T, f
 end
+=#
 
 function checked_abs(x::XBS)
     r = ifelse(x<0, -x, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -452,7 +452,7 @@ end
 
 @testset "checked operations" begin
     for X in (XInts..., Int256, UInt256)
-        if sizeof(X) != 3 # bug with [U]Int24, cf. Julia issue #34288
+        if VERSION >= v"1.8" || sizeof(X) != 3 # bug with [U]Int24, cf. Julia issue #34288
             @test Base.sub_with_overflow(typemin(X)+X(3), X(3)) == (typemin(X), false)
             @test Base.sub_with_overflow(typemin(X)+X(2), X(3)) == (typemax(X), true)
             @test Base.add_with_overflow(typemax(X)-X(3), X(3)) == (typemax(X), false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -451,13 +451,13 @@ end
 end
 
 @testset "checked operations" begin
-    for X in XInts
+    for X in (XInts..., Int256, UInt256)
         if sizeof(X) != 3 # bug with [U]Int24, cf. Julia issue #34288
             @test Base.sub_with_overflow(typemin(X)+X(3), X(3)) == (typemin(X), false)
             @test Base.sub_with_overflow(typemin(X)+X(2), X(3)) == (typemax(X), true)
             @test Base.add_with_overflow(typemax(X)-X(3), X(3)) == (typemax(X), false)
             @test Base.add_with_overflow(typemax(X)-X(2), X(3)) == (typemin(X), true)
-            if X <: Signed # unimplemented otherwise (problem with LLVM)
+            if VERSION >= v"1.11-" || X <: Signed # unimplemented otherwise (problem with LLVM)
                 @test Base.mul_with_overflow(typemax(X), X(1))  == (typemax(X), false)
                 @test Base.mul_with_overflow(typemax(X), X(2))  == (-2 % X,     true)
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -451,7 +451,7 @@ end
 end
 
 @testset "checked operations" begin
-    for X in (XInts..., Int256, UInt256)
+    for X in XInts
         if VERSION >= v"1.8" || sizeof(X) != 3 # bug with [U]Int24, cf. Julia issue #34288
             @test Base.sub_with_overflow(typemin(X)+X(3), X(3)) == (typemin(X), false)
             @test Base.sub_with_overflow(typemin(X)+X(2), X(3)) == (typemax(X), true)


### PR DESCRIPTION
Following #48, I believe `mul_with_overflow` can also use `checked_smul_int`/`checked_umul_int`, starting from v1.11.